### PR TITLE
Update string-slicing-concatenation-worksheet.md

### DIFF
--- a/lessons/08-programming-grammar/string-slicing-concatenation-worksheet.md
+++ b/lessons/08-programming-grammar/string-slicing-concatenation-worksheet.md
@@ -68,7 +68,7 @@ my_string.slice(0) << "i" + "!"
 
 10.
 ```ruby
-my_string = I love ruby"
+my_string = "I love ruby"
 my_string.slice(7, 4).concat(my_string.slice(2...6)) + my_string.slice(0)
 ```
 
@@ -80,7 +80,7 @@ my_string = "I love ruby"
 
 12.
 ```ruby
-my_string = I love ruby"
+my_string = "I love ruby"
 my_string.slice(2, 4) << my_string.slice(7...11).concat(my_string.slice(2...6))
 ```
 


### PR DESCRIPTION
I was working through the exercises and numbers 10 and 12 didn't have an opening ". In irb it changed the prompt to have the " in it. I googled what that meant and was able to find the solution on stackoverflow.

It didn't seem like finding missing " was part of the exercise so I thought I'd fix it for the next person. If it was intentional please disregard this pull request.