### PR TITLE
Adding Windows Instructions, Ruby 2.4.1 or greater, application website

### DIFF
--- a/preparing-for-ada/applying-to-ada/readme.md
+++ b/preparing-for-ada/applying-to-ada/readme.md
@@ -1,1 +1,3 @@
-Coming soon ...
+Applicants who have completed this JumpStart curriculum including all the coding exercises, are better prepared for the application process as well as to start as a new student at Ada Developers Academy.
+
+Learn more about the application process for Ada Developers Academy on [this site](https://www.adadevelopersacademy.org/applicants).

--- a/preparing-for-ada/applying-to-ada/readme.md
+++ b/preparing-for-ada/applying-to-ada/readme.md
@@ -1,3 +1,3 @@
-Applicants who have completed this JumpStart curriculum including all the coding exercises, are better prepared for the application process as well as to start as a new student at Ada Developers Academy.
+Applicants who have completed this JumpStart curriculum including all the coding exercises, are better prepared for the application process and therefore becoming a new student at Ada Developers Academy.
 
 Learn more about the application process for Ada Developers Academy on [this site](https://www.adadevelopersacademy.org/applicants).

--- a/preparing-to-code/environment-setup/README.md
+++ b/preparing-to-code/environment-setup/README.md
@@ -31,7 +31,7 @@ The purpose of these notes is to help you install and configure the software we 
 * [Google Chrome (web browser)](https://www.google.com/chrome/browser/desktop/index.html)
 * [Atom (text editor)](https://atom.io/)
 * [Ruby Version Manager (rvm) (package manager)](https://rvm.io/)
-* [Ruby 2.3.0](https://www.ruby-lang.org/en/)
+* [Ruby 2.4.1](https://www.ruby-lang.org/en/)
 
 #### OS X _El Capitan_ or _Sierra_
 _OS X_ is the name of the operating system found on Apple computers. Apple likes to give the versions of their operating systems odd names. They used to be big cats (Cheetah, Puma, Jaguar, Panther, Tiger, Leopard, Snow Leopard, Lion, and Mountain Lion). Now it's... I don't even know. Anyway, the two most recent versions are _Sierra_ and _El Capitan_. For Ada, your computer must be running one of these two versions of _OS X_, with preference given to _El Capitan_.
@@ -65,7 +65,7 @@ At Ada we will be using [Atom](https://atom.io/), a text editor, to write our co
 ##### Atom installation steps
 * Navigate to the [Atom](https://atom.io/) website
 * Download the zip to your Applications folder
-* Unzip the folder, by double-clicking, or right-click _Open_ 
+* Unzip the folder, by double-clicking, or right-click _Open_
 * Drag Atom to your dock and open it up
 * Navigate to the Atom menu (at the top of your screen) and select _Install Shell Commands_.
 
@@ -86,7 +86,7 @@ Run `$ brew doctor`. Brew is super great at telling you what else it may need. S
 
 Installing _rvm_ is done in the Terminal: `$ \curl -sSL https://get.rvm.io | bash -s stable`
 
-The installation won't take long. When it's done, close your Terminal (⌘-Q) and then reopen it. You can find the ⌘ or 'Command' key next to your spacebar.    On a Mac pressing both command and 'Q' will quit the active application. 
+The installation won't take long. When it's done, close your Terminal (⌘-Q) and then reopen it. You can find the ⌘ or 'Command' key next to your spacebar.    On a Mac pressing both command and 'Q' will quit the active application.
 
 Verify all's well by running `$ rvm -v`. You should see something like `rvm 1.28.0 (latest)`.
 

--- a/preparing-to-code/environment-setup/README.md
+++ b/preparing-to-code/environment-setup/README.md
@@ -31,7 +31,7 @@ The purpose of these notes is to help you install and configure the software we 
 * [Google Chrome (web browser)](https://www.google.com/chrome/browser/desktop/index.html)
 * [Atom (text editor)](https://atom.io/)
 * [Ruby Version Manager (rvm) (package manager)](https://rvm.io/)
-* [Ruby 2.4.1](https://www.ruby-lang.org/en/)
+* [Ruby (latest stable version of Ruby)](https://www.ruby-lang.org/en/)
 
 #### OS X _El Capitan_ or _Sierra_
 _OS X_ is the name of the operating system found on Apple computers. Apple likes to give the versions of their operating systems odd names. They used to be big cats (Cheetah, Puma, Jaguar, Panther, Tiger, Leopard, Snow Leopard, Lion, and Mountain Lion). Now it's... I don't even know. Anyway, the two most recent versions are _Sierra_ and _El Capitan_. For Ada, your computer must be running one of these two versions of _OS X_, with preference given to _El Capitan_.

--- a/preparing-to-code/readme.md
+++ b/preparing-to-code/readme.md
@@ -1,7 +1,7 @@
 # Ada Developers Academy Jump Start Curriculum
 
-## Preparing to Code 
-In these lessons you will learn how to navigate MaxOSX, learn about the languages that Ada teaches, start using the terminal, and setup your development environment
+## Preparing to Code
+In these lessons you will learn how to navigate Mac OS X, learn about the languages that Ada teaches, start using the terminal, and setup your development environment.
 
 | Order | Lesson |
 | :--- | :--- |
@@ -10,3 +10,10 @@ In these lessons you will learn how to navigate MaxOSX, learn about the language
 | 05 | [Ada programming languages](./ada-languages) |
 | 06 | [Terminal](./terminal/) |
 | 07 | [Environment Setup](./environment-setup/) |
+
+Notes:
+* If you are *a student enrolled to begin your cohort in upcoming months*, you are required to follow all the lessons.
+* If you are *an applicant and do not currently have a machine with Mac OS X*, please complete the lessons on [Effective Internet Searching](./internet-searching/) and [Ada programming languages](./ada-languages). On your Windows machine, to get your *environment setup*, please use the following links and follow instructions to install the these applications.
+- [Google Chrome](https://www.google.com/chrome/)
+- [Atom]( https://atom.io/)
+-[Ruby](https://www.ruby-lang.org/en/documentation/installation/#rubyinstaller) Install the latest stable released version of Ruby (not a preview release). Once Ruby is installed, Interactive Ruby (`irb`) should be available on the command prompt on your Windows machine. Read more on [irb](https://github.com/Ada-Developers-Academy/jump-start/tree/master/preparing-to-code/environment-setup#interactive-ruby)

--- a/preparing-to-code/readme.md
+++ b/preparing-to-code/readme.md
@@ -11,9 +11,9 @@ In these lessons you will learn how to navigate Mac OS X, learn about the langua
 | 06 | [Terminal](./terminal/) |
 | 07 | [Environment Setup](./environment-setup/) |
 
-Notes:
+**Notes**
 * If you are *a student enrolled to begin your cohort in upcoming months*, you are required to follow all the lessons.
 * If you are *an applicant and do not currently have a machine with Mac OS X*, please complete the lessons on [Effective Internet Searching](./internet-searching/) and [Ada programming languages](./ada-languages). On your Windows machine, to get your *environment setup*, please use the following links and follow instructions to install the these applications.
 - [Google Chrome](https://www.google.com/chrome/)
 - [Atom]( https://atom.io/)
--[Ruby](https://www.ruby-lang.org/en/documentation/installation/#rubyinstaller) Install the latest stable released version of Ruby (not a preview release). Once Ruby is installed, Interactive Ruby (`irb`) should be available on the command prompt on your Windows machine. Read more on [irb](https://github.com/Ada-Developers-Academy/jump-start/tree/master/preparing-to-code/environment-setup#interactive-ruby)
+- [Ruby](https://www.ruby-lang.org/en/documentation/installation/#rubyinstaller) Install the latest stable released version of Ruby (not a preview release). Once Ruby is installed, Interactive Ruby (`irb`) should be available on the command prompt on your Windows machine. Read more on [irb](https://github.com/Ada-Developers-Academy/jump-start/tree/master/preparing-to-code/environment-setup#interactive-ruby)


### PR DESCRIPTION
Adds instructions for applicants with only access to Windows machines #64, completes update to have Ruby install instructions for 2.4.0 or greater #73 and updates the placeholder readme file to instead link to our applicants' portion of the website.
